### PR TITLE
Add link to PDF in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-﻿# Endim
+﻿[Länk till PDF](https://docs.google.com/viewer?url=https://raw.githubusercontent.com/emilwihlander/Endim/master/Endimensionell_analys.pdf)
+# Endim
 Efter att jag hösten 2015 läst kursen Endimensionell analys på LTH upptäckte jag att jag saknade ett hjälpmedel inför tentaplugget: Lösningsexempel för uppgifterna i boken. Jag kunde sitta i tiotals minuter med en och samma uppgift eftersom jag använde fel metod/skrev av värden fel/gjorde ett räknefel osv. Detta är tid som är mycket mer väl spenderad på att lösa fler uppgifter så för att folk i framtiden ska kunna undvika detta tänker jag göra lösningsförslag till ALLA uppgifter i Boken "Övningar i Endimensionell analys" av Jonas Månsson & Patrik Nordbeck med referenser till tillhörande bok "Endimensionell analys".
 # Status
 Hittills är de fem första kapitlen färdiga (28/4/16)


### PR DESCRIPTION
Det folk letar efter när de hittar in till repot är ju PDF:en, denna PR lägger en länk som man kan kolla på den i Google Drives PDF viewer.

Då får man alltså se senaste master `https://raw.githubusercontent.com/emilwihlander/Endim/master/Endimensionell_analys.pdf` pdf:en 